### PR TITLE
Fix validation of release docker images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -76,7 +76,7 @@ jobs:
           mkdir -p  "$OUTPUTS_DIR"
           jq -c '{
             "${{ matrix.app.name }}": (
-                .["image.name"] + "@" + .["containerimage.digest"]
+                "${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}/${{ matrix.app.name }}@" + .["containerimage.digest"]
             )
           }' <<EOF >> "$OUTPUTS_DIR/image"
             ${{ steps.build_and_push.outputs.metadata }}


### PR DESCRIPTION
Previous code assumed that gathered image name contains a single value only. It is not true if tags are used where it is a coma-separated list of names.