### PR TITLE
Add upload token configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: go vet ./...
       - run: go test -v ${{ matrix.env.coverage && '-coverprofile=profile.cov' }} ./...
-        continue-on-error: ${{ matrix.env.continue-on-error }}
+        continue-on-error: ${{ matrix.env['continue-on-error'] }}
       - uses: shogo82148/actions-goveralls@v1
         if: ${{ matrix.env.coverage }}
         with:

--- a/pkg/cmd/cinode_web_proxy/root.go
+++ b/pkg/cmd/cinode_web_proxy/root.go
@@ -86,6 +86,7 @@ func executeWithConfig(ctx context.Context, cfg *config) error {
 	return httpserver.RunGracefully(ctx,
 		handler,
 		httpserver.ListenPort(cfg.port),
+		httpserver.Logger(log),
 	)
 }
 

--- a/pkg/cmd/public_node/root_test.go
+++ b/pkg/cmd/public_node/root_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cinode/go/testvectors/testblobs"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
 )
 
 func TestGetConfig(t *testing.T) {
@@ -150,6 +151,7 @@ func TestExecuteWithConfig(t *testing.T) {
 		}()
 		err := executeWithConfig(ctx, config{
 			mainDSLocation: "memory://",
+			log:            slog.Default(),
 		})
 		require.NoError(t, err)
 	})

--- a/pkg/datastore/webinterface_test.go
+++ b/pkg/datastore/webinterface_test.go
@@ -28,20 +28,17 @@ import (
 
 	"github.com/cinode/go/pkg/common"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
 )
 
-// import (
-// 	"bytes"
-// 	"io"
-// 	"mime/multipart"
-// 	"net/http"
-// 	"net/http/httptest"
-// 	"testing"
-// )
-
 func testServer(t *testing.T) string {
+	log := slog.New(slog.NewTextHandler(io.Discard))
+
 	// Test web interface and web connector
-	server := httptest.NewServer(WebInterface(InMemory()))
+	server := httptest.NewServer(WebInterface(
+		InMemory(),
+		WebInterfaceOptionLogger(log),
+	))
 	t.Cleanup(func() { server.Close() })
 	return server.URL + "/"
 }

--- a/testvectors/testblobs/base.go
+++ b/testvectors/testblobs/base.go
@@ -35,6 +35,10 @@ type TestBlob struct {
 }
 
 func (s *TestBlob) Put(baseUrl string) error {
+	return s.PutWithAuthToken(baseUrl, "")
+}
+
+func (s *TestBlob) PutWithAuthToken(baseUrl, authToken string) error {
 	finalUrl, err := url.JoinPath(baseUrl, base58.Encode(s.BlobName))
 	if err != nil {
 		return err
@@ -46,6 +50,10 @@ func (s *TestBlob) Put(baseUrl string) error {
 		bytes.NewReader(s.UpdateDataset))
 	if err != nil {
 		return err
+	}
+
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/testvectors/testblobs/base.go
+++ b/testvectors/testblobs/base.go
@@ -35,10 +35,10 @@ type TestBlob struct {
 }
 
 func (s *TestBlob) Put(baseUrl string) error {
-	return s.PutWithAuthToken(baseUrl, "")
+	return s.PutWithAuth(baseUrl, "", "")
 }
 
-func (s *TestBlob) PutWithAuthToken(baseUrl, authToken string) error {
+func (s *TestBlob) PutWithAuth(baseUrl, username, password string) error {
 	finalUrl, err := url.JoinPath(baseUrl, base58.Encode(s.BlobName))
 	if err != nil {
 		return err
@@ -52,8 +52,8 @@ func (s *TestBlob) PutWithAuthToken(baseUrl, authToken string) error {
 		return err
 	}
 
-	if authToken != "" {
-		req.Header.Set("Authorization", "Bearer "+authToken)
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
 	}
 
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
Such upload token is a trivial protection against
unauthorized upload of data. Even if such data would pass the validation, huge amounts of data can be generated in order to perform a DoS attack by abusing storage requirements of the node.