### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 on: [push]
 jobs:
   tests:
+    permissions:
+      contents: read
     strategy:
       matrix:
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/cinode/go/security/code-scanning/13](https://github.com/cinode/go/security/code-scanning/13)

The fix involves explicitly adding a `permissions` key to assign the least privilege required for the workflow. In this workflow, write permissions to repository contents or other resources are not necessary: we only need to read the code to run tests/check coverage. Therefore, we should set `permissions: contents: read` either at the top-level of the workflow, or at the job level. If it's possible that another job would be added in the future requiring different permissions, add it at the job level. Since there's only one job (`tests`), adding at the job level directly above the `strategy:` key is sufficient and matches the line highlighted by CodeQL.  
Specifically, in the `.github/workflows/tests.yml` file, add the following immediately after the `tests:` job definition and before `strategy:`:

```yaml
    permissions:
      contents: read
```

No imports, definitions, or other changes required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
