### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -90,6 +90,8 @@ jobs:
   
   images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: build-and-push-image
     env:
       OUTPUTS_DIR: /tmp/outputs


### PR DESCRIPTION
Potential fix for [https://github.com/cinode/go/security/code-scanning/4](https://github.com/cinode/go/security/code-scanning/4)

To fix this issue, the `images` job should have an explicit `permissions:` block specifying the minimum permissions needed. Reviewing the job's actions:
- It downloads artifacts (read access to `contents` is sufficient for downloading artifacts generated in the workflow run).
- It does not push, create, or modify repository contents, issues, packages, etc.
- Downloading artifacts only requires `contents: read`.

Therefore, the minimal, correct fix is to add:
```yaml
permissions:
  contents: read
```
just beneath `runs-on: ubuntu-latest` within the `images` job (line 92).

No new imports or definitions are needed; just a simple addition of this block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
